### PR TITLE
Encode spaces in icon urls

### DIFF
--- a/smartapps/bsileo/pool-controller.src/pool-controller.groovy
+++ b/smartapps/bsileo/pool-controller.src/pool-controller.groovy
@@ -19,9 +19,9 @@ definition(
 		author: "Brad Sileo",
 		description: "This is a SmartApp to connect to the nodejs_poolController and create devices to manage it within SmartThings",
 		category: "SmartThings Labs",
-		iconUrl: "http://cdn.device-icons.smartthings.com/Health & Wellness/health2-icn.png",
-		iconX2Url: "http://cdn.device-icons.smartthings.com/Health & Wellness/health2-icn@2x.png",
-		iconX3Url: "http://cdn.device-icons.smartthings.com/Health & Wellness/health2-icn@3x.png")
+		iconUrl: "http://cdn.device-icons.smartthings.com/Health%20&%20Wellness/health2-icn.png",
+		iconX2Url: "http://cdn.device-icons.smartthings.com/Health%20&%20Wellness/health2-icn@2x.png",
+		iconX3Url: "http://cdn.device-icons.smartthings.com/Health%20&%20Wellness/health2-icn@3x.png")
 
 
 preferences {


### PR DESCRIPTION
There have been a few reports of users having issues with seeing SmartApps in the new SmartThings app which looks to be related to unencoded spaces in the icon urls. Encoding the spaces alleviates the issue.

https://community.smartthings.com/t/unable-to-see-any-smartapps-on-iphone/211005/9

https://community.smartthings.com/t/new-smartthings-app-no-smartapps/206577/36